### PR TITLE
Add Mysql validation query for quartz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 release/avws-tools.sh
 src/main/webapp/public/bower
 src/main/webapp/public/dist
+aws/*.cfg

--- a/src/main/java/net/airvantage/sched/app/ServiceLocator.java
+++ b/src/main/java/net/airvantage/sched/app/ServiceLocator.java
@@ -67,7 +67,6 @@ public class ServiceLocator {
                     new JobLockDaoImpl(dataSource),
                     new JobSchedulingDaoImpl(getScheduler()));
 
-            // jobStateDao = new DummyJobStateDao();
         }
         return jobStateDao;
     }
@@ -81,6 +80,9 @@ public class ServiceLocator {
             ds.setDatabaseName(config.getString(Keys.Db.DB_NAME));
             ds.setUser(config.getString(Keys.Db.USER));
             ds.setPassword(config.getString(Keys.Db.PASSWORD));
+            // Attempt to fix https://github.com/AirVantage/av-sched/issues/6
+            ds.setAutoReconnect(true);
+            
             dataSource = ds;
         }
         return dataSource;

--- a/src/main/java/net/airvantage/sched/quartz/QuartzClusteredSchedulerFactory.java
+++ b/src/main/java/net/airvantage/sched/quartz/QuartzClusteredSchedulerFactory.java
@@ -46,8 +46,11 @@ public class QuartzClusteredSchedulerFactory {
         props.put("org.quartz.dataSource.sched.URL", jdbcUrl);
         props.put("org.quartz.dataSource.sched.user", config.getString("av-sched.db.user"));
         props.put("org.quartz.dataSource.sched.password", config.getString("av-sched.db.password"));
-        // ? props.put("org.quartz.jobStore.dataSource.sched.maxConnections", ?);
-        // ? props.put("org.quartz.jobStore.dataSource.sched.validationQuery", ?);
+        
+        // Attempt to fix https://github.com/AirVantage/av-sched/issues/6 
+        props.put("org.quartz.dataSource.sched.validationQuery", "SELECT 1");
+        props.put("org.quartz.dataSource.sched.validateOnCheckout", true);
+        
 
         schedFact.initialize(props);
         Scheduler scheduler = schedFact.getScheduler();


### PR DESCRIPTION
Attempt to fix issue #6.
Quartz should now validate connections (by doing a safe mysql query,
'SELECT 1'.
Hopefully this will prevent the app from using closed connections.
DataSource used by DbUtils query also has the flag "autoReconnect" to
true, for double measure.

Inspired by quartz doc : git push --set-upstream origin bugfix/6-mysql-reconnection-errors

To @jvermillard for opinion...